### PR TITLE
Added Correction position and length to response

### DIFF
--- a/lib/gingerice/parser.rb
+++ b/lib/gingerice/parser.rb
@@ -49,7 +49,9 @@ module Gingerice
           corrections << {
             'text'       => text[from..to],
             'correct'    => r['Suggestions'][0]['Text'],
-            'definition' => r['Suggestions'][0]['Definition']
+            'definition' => r['Suggestions'][0]['Definition'],
+            'start'      => from,
+            'length'     => to.to_i - from.to_i + 1
           }
         end
 

--- a/test/test_gingerice.rb
+++ b/test/test_gingerice.rb
@@ -50,6 +50,8 @@ class TestGingerice < Test::Unit::TestCase
     assert_equal text, result['text']
     assert_equal 'The smell of flowers brings back memories.', result['result']
     assert_equal 3, result['corrections'].count
+    assert_equal 4, result['corrections'].first['start']
+    assert_equal 5, result['corrections'].first['length']
   end
 
   def test_exceptions


### PR DESCRIPTION
Basically to remove any ambiguity where you have multiple occurrences of the same string where one is correct and the other is not.  Or to enable easy highlighting of incorrect pieces within an html string.  Having the positions and lengths should in general be useful.
